### PR TITLE
Correctly use base URL from credentials in test file

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,11 +25,11 @@ func main() {
 
 	if err != nil {
 		fmt.Printf("Failed to load cerb creds: %v\n", err)
-		fmt.Printf("\nSETUP Instructions: Copy sample-creds.json to ~/.config/cerb/creds.json and edit to use your api keys or pass in the -cerb-creds parameter to speficy where to find it.")
+		fmt.Printf("\nSETUP Instructions: Copy sample-creds.json to ~/.config/cerb/creds.json and edit to use your api keys or pass in the -cerb-creds parameter to specify where to find it.")
 		return
 	}
 
-	c := cerb.NewCerberus(*creds, *client, "https://agilebits.cerb.me/rest/")
+	c := cerb.NewCerberus(*creds, *client)
 	testCreateTicket(c)
 	// testFindTicketsByEmail(c)
 	// testListOpenTickets(c)

--- a/sample-creds.json
+++ b/sample-creds.json
@@ -1,4 +1,5 @@
 {
     "access-key": "XXX",
-    "access-secret": "YYY"
+    "access-secret": "YYY",
+    "restAPIBaseURL": "https://ZZZ.cerb.me/rest/"
 }


### PR DESCRIPTION
We were still hardcoding the `restAPIBaseURL`, which is now provided in the credentials file.