### PR TITLE
Allow ticket Participant field to be specified when creating ticket

### DIFF
--- a/cerb/cerb.go
+++ b/cerb/cerb.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // CerberusCreds contains the keys needed to connect to the Cerberus API. @see https://cerb.ai/docs/api/authentication/
@@ -82,10 +83,11 @@ type CustomerQuestion struct {
 	BucketID int
 	GroupID  int
 
-	To      string
-	From    string
-	Subject string
-	Content string
+	To           string
+	From         string
+	Participants []string
+	Subject      string
+	Content      string
 
 	CustomFields []CustomField
 	Notes        string
@@ -136,12 +138,13 @@ func (c Cerberus) CreateMessage(q CustomerQuestion) (*CreateMessageResponse, err
 	if status == "" {
 		status = "o"
 	}
+	participants := strings.Join(q.Participants, ", ")
 	form := url.Values{}
 	form.Set("fields[group_id]", strconv.Itoa(q.GroupID))
 	form.Set("fields[bucket_id]", strconv.Itoa(q.BucketID))
 	form.Set("fields[status]", status)
 	form.Set("fields[subject]", q.Subject)
-	form.Set("fields[participants]", q.To)
+	form.Set("fields[participants]", participants)
 
 	var ticket CreateTicketResponse
 	err := c.performRequest(http.MethodPost, "records/ticket/create.json", nil, form, &ticket)

--- a/cerb/cerb.go
+++ b/cerb/cerb.go
@@ -141,7 +141,7 @@ func (c Cerberus) CreateMessage(q CustomerQuestion) (*CreateMessageResponse, err
 	form.Set("fields[bucket_id]", strconv.Itoa(q.BucketID))
 	form.Set("fields[status]", status)
 	form.Set("fields[subject]", q.Subject)
-	form.Set("fields[participants]", "customer@example.com")
+	form.Set("fields[participants]", q.To)
 
 	var ticket CreateTicketResponse
 	err := c.performRequest(http.MethodPost, "records/ticket/create.json", nil, form, &ticket)

--- a/main.go
+++ b/main.go
@@ -38,13 +38,14 @@ func main() {
 
 func testCreateTicket(c cerb.Cerberus) {
 	q := cerb.CustomerQuestion{
-		BucketID: 1049,
-		GroupID:  900,
-		Content:  "Hello there! ❤️",
-		From:     "dave+gocerb@1password.com",
-		Notes:    "Some exciting notes that stand out in a stunning yellow. 🎨",
-		Subject:  "GoCerb! 🤘🏼",
-		To:       "support@1password.com",
+		BucketID:     1049,
+		GroupID:      900,
+		Content:      "Hello there! ❤️",
+		From:         "dave+gocerb@1password.com",
+		Notes:        "Some exciting notes that stand out in a stunning yellow. 🎨",
+		Subject:      "GoCerb! 🤘🏼",
+		To:           "support@1password.com",
+		Participants: []string{"customer@example.com"},
 		CustomFields: []cerb.CustomField{
 			cerb.CustomField{
 				ID:    37, // Found using Search > Custom Fields in your Cerb workspace


### PR DESCRIPTION
We now use a `Participants` field on `CustomerQuestion`, instead of hard-coding an example address.