### PR TITLE
Expose all tickets and create sticky notes

### DIFF
--- a/cerb/cerb.go
+++ b/cerb/cerb.go
@@ -242,7 +242,7 @@ func (c Cerberus) SetCustomTicketFields(ticketID int, customFields []CustomField
 
 // FindTicketsByEmail finds all tickets for the given email address.
 // Cerb's API is paginated but we do not implement that, so this only returns
-// the first ten results.
+// the first 250 results.
 func (c Cerberus) FindTicketsByEmail(email string) (*[]CerberusTicket, error) {
 	limit := 250 // Maximum of 250 enforced by server
 	params := url.Values{}

--- a/cerb/cerb.go
+++ b/cerb/cerb.go
@@ -244,8 +244,10 @@ func (c Cerberus) SetCustomTicketFields(ticketID int, customFields []CustomField
 // Cerb's API is paginated but we do not implement that, so this only returns
 // the first ten results.
 func (c Cerberus) FindTicketsByEmail(email string) (*[]CerberusTicket, error) {
+	limit := 250 // Maximum of 250 enforced by server
 	params := url.Values{}
 	params.Set("q", "messages.first:(sender:(email:"+email+"))")
+	params.Set("limit", strconv.Itoa(limit))
 
 	var r CerberusTicketSearchResults
 	err := c.performRequest(http.MethodGet, "records/ticket/search.json", params, nil, &r)

--- a/cerb/cerb.go
+++ b/cerb/cerb.go
@@ -41,6 +41,8 @@ type CerberusTicket struct {
 	Subject     string `json:"subject"`
 	Status      string `json:"status"`
 	URL         string `json:"url"`
+	Created     int    `json:"created"`
+	ClosedAt    int    `json:"closed_at"`
 }
 
 // CerberusTicketSearchResults is the raw structure returned by the Cerberus search API when looking for tickets. Most often you want to call a function that hides all these details and work with a []CerberusTicket instead.
@@ -172,10 +174,10 @@ func (c Cerberus) CreateMessage(q CustomerQuestion) (*CreateMessageResponse, err
 	c.SetCustomTicketFields(ticket.ID, q.CustomFields)
 
 	if q.Notes != "" {
-		err = c.CreateComment(ticket.ID, q.Notes)
+		err = c.CreateNote(message.ID, q.Notes)
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create comment on ticket %d: %v", ticket.ID, err)
+			return nil, fmt.Errorf("Failed to create sticky note on message %d: %v", message.ID, err)
 		}
 	}
 
@@ -186,17 +188,35 @@ func (c Cerberus) CreateMessage(q CustomerQuestion) (*CreateMessageResponse, err
 func (c Cerberus) CreateComment(ticketID int, comment string) error {
 	params := url.Values{}
 	params.Set("fields[author__context]", "ticket")
-	params.Set("fields[author_id]", strconv.Itoa(17))
+	params.Set("fields[author_id]", strconv.Itoa(ticketID))
 	params.Set("fields[comment]", comment)
 	params.Set("fields[target__context]", "ticket")
 	params.Set("fields[target_id]", strconv.Itoa(ticketID))
 
 	var ticket CreateCommentResponse
-	fmt.Println("CREATING COMMENTS")
 	err := c.performRequest(http.MethodPost, "records/comment/create.json", params, nil, &ticket)
 
 	if err != nil {
 		return fmt.Errorf("Failed to create ticket comment: %v", err)
+	}
+
+	return nil
+}
+
+// CreateNote adds a sticky note to an existing message
+func (c Cerberus) CreateNote(messageID int, note string) error {
+	params := url.Values{}
+	params.Set("fields[author__context]", "message")
+	params.Set("fields[author_id]", strconv.Itoa(messageID))
+	params.Set("fields[comment]", note)
+	params.Set("fields[target__context]", "message")
+	params.Set("fields[target_id]", strconv.Itoa(messageID))
+
+	var ticket CreateCommentResponse
+	err := c.performRequest(http.MethodPost, "records/comment/create.json", params, nil, &ticket)
+
+	if err != nil {
+		return fmt.Errorf("Failed to create ticket sticky note: %v", err)
 	}
 
 	return nil
@@ -220,10 +240,12 @@ func (c Cerberus) SetCustomTicketFields(ticketID int, customFields []CustomField
 	return nil
 }
 
-// FindTicketsByEmail finds all open tickets for the given email address.
+// FindTicketsByEmail finds all tickets for the given email address.
+// Cerb's API is paginated but we do not implement that, so this only returns
+// the first ten results.
 func (c Cerberus) FindTicketsByEmail(email string) (*[]CerberusTicket, error) {
 	params := url.Values{}
-	params.Set("q", "status:[o] messages.first:(sender:(email:"+email+"))")
+	params.Set("q", "messages.first:(sender:(email:"+email+"))")
 
 	var r CerberusTicketSearchResults
 	err := c.performRequest(http.MethodGet, "records/ticket/search.json", params, nil, &r)


### PR DESCRIPTION
## Summary

We tell a few fibs in `gocerb` 😉 I've tried to correct a few of them:

- `CustomerQuestion` has a Notes property, but this previously resulted in a comment. We now create a note.
- `CreateComment` has a hardcoded ticket ID as the author. We now use the ticket ID provided.
- `FindTicketsByEmail` doesn't indicate it searches only _open_ tickets, so I've removed that restriction. It now also returns 250 results, which is the maximum we can have without implementing pagination (and breaking backwards compatibility).

I've also exposed the `created` and `closed_at` fields which can be useful for determining if a ticket is recent enough to be interesting.

## Extra Details

It looks weird to have a message record be the "author" of a sticky note. What we really want to do is start working out who we could better attribute records to - a Cerb bot maybe?

I'm hoping making `FindTicketsByEmail` return closed tickets doesn't break anything that's already using `gocerb`. If you're aware of a project that would be affected, I could create a new function instead. I just wanted to make the behaviour match the name before it's too late.